### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/AlexToapanta/9d5e7914-9a8f-4815-b892-bfb9b5ea8d59/38170e1c-8a26-4dbf-8928-4efff6bd53ba/_apis/work/boardbadge/bb32d41c-b528-441b-a364-14a98418fa87)](https://dev.azure.com/AlexToapanta/9d5e7914-9a8f-4815-b892-bfb9b5ea8d59/_boards/board/t/38170e1c-8a26-4dbf-8928-4efff6bd53ba/Microsoft.RequirementCategory)
 # ado_integration
 Proof of concept for azure devops integration 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/AlexToapanta/9d5e7914-9a8f-4815-b892-bfb9b5ea8d59/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.